### PR TITLE
feat: fixed return of createExperiment so that it returns an experiment ID as a string, instead of an object

### DIFF
--- a/mlflow/src/tracking_server/experiment_management.js
+++ b/mlflow/src/tracking_server/experiment_management.js
@@ -30,17 +30,17 @@ async function createExperiment(name, artifact_location = '', tags = []) {
   }
 
   const data = await response.json();
-  // console.log('return from createExperiment: ', data);
-  return data;
+  // console.log('return from createExperiment: ', data.experiment_id);
+  return data.experiment_id;
 }
 
 // test ****************************************************************************************************************************************
 const testCreateExperiment = async () => {
-  const log = await createExperiment('test_experiment_postman21');
+  const log = await createExperiment('test_experiment_postman22');
   return console.log(log);
 };
 // uncomment below ---
-// testCreateExperiment();
+testCreateExperiment();
 
 /**
  * Search experiments.


### PR DESCRIPTION
feat: fixed return of createExperiment so that it returns an experiment ID as a string, instead of an object

## Linked issue/ticket

https://trello.com/c/bHTTqZMo/5-module-experiment-management

## Description

fixed return of createExperiment so that it returns an experiment ID as a string, instead of an object

## Reproduction steps

n/a

## Checklist

- [x] I've followed the [Contributing guidelines](https://github.com/oslabs-beta/.github/blob/main/docs/CONTRIBUTING.md)
- [x] I've titled my PR according to the [Conventional Commits spec](https://conventionalcommits.org)
- [ ] I've added tests that fail without this PR but pass with it
- [x] I've linted, tested, and commented my code
- [ ] I've updated documentation (if appropriate)
